### PR TITLE
53 rendering changes

### DIFF
--- a/generators/lexicon/engdict.xsl
+++ b/generators/lexicon/engdict.xsl
@@ -15,9 +15,7 @@
 
     <xsl:template match="/" mode="engdict">
       <xsl:variable name="doc" select="."/>
-      <html><head>
-        <title>English-Rikchik Dictionary</title>
-      </head><body>
+      <page-body href="engdict.html" title="English-Rikchik Dictionary">
       <h1>English-Rikchik Dictionary</h1>
       <p>An index by English gloss to readings, compounds, and idioms.</p>
       <xsl:for-each select="tokenize('a b c d e f g h i j k l m n o p q r s t u v w x y z',' ')">
@@ -36,7 +34,7 @@
           </xsl:apply-templates>
         </dl>
       </xsl:for-each>
-      </body></html>
+      </page-body>
     </xsl:template>
 
     <!-- skips -->

--- a/generators/lexicon/morphemepages.xsl
+++ b/generators/lexicon/morphemepages.xsl
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 version="1.1">
+ <xsl:import href="rikbasics.xsl"/>
  <xsl:variable name="lang" select="'en'"/>
 
  <xsl:output method="html" encoding="iso-8859-1"/>
@@ -16,20 +17,18 @@
  </xsl:template>
 
  <xsl:template match="morpheme" mode="morphemepage">
-  <xsl:result-document href="dictionary/{@name}.html" method="html" encoding="iso-8859-1">
-  <xsl:message>Writing file for <xsl:value-of select="@name"/></xsl:message>
-  <html><head>
-   <title><xsl:value-of select="@name"/></title>
-  </head><body bgcolor="#FFFFFF">
-   <img src="http://www.suberic.net/~dmm/rikchik/images/blunt/5/m{@name}.png" alt="{@name}" width="70" height="70"/>
-   <xsl:apply-templates select="glyph/note" mode="noteref"/>
-   <h1><xsl:value-of select="@name"/></h1>
-   <b>Paradigm:</b>&#xA0;<xsl:value-of select="@paradigm"/><br/>
-   <xsl:apply-templates select="readings | roles | idioms | compounds" mode="morphemepage"/> 
-   <hr/>
-   <xsl:apply-templates select=".//note" mode="morphemepage" />
-  </body></html>
-  </xsl:result-document>
+   <xsl:variable name="output">
+     <page-body href="dictionary/{@name}.html" title="{@name}">
+       <img src="http://www.suberic.net/~dmm/rikchik/images/blunt/5/m{@name}.png" alt="{@name}" width="70" height="70"/>
+       <xsl:apply-templates select="glyph/note" mode="noteref"/>
+       <h1><xsl:value-of select="@name"/></h1>
+       <b>Paradigm:</b>&#xA0;<xsl:value-of select="@paradigm"/><br/>
+       <xsl:apply-templates select="readings | roles | idioms | compounds" mode="morphemepage"/> 
+       <hr/>
+       <xsl:apply-templates select=".//note" mode="morphemepage" />
+     </page-body>
+   </xsl:variable>
+   <xsl:apply-templates select="$output" mode="output"/>
  </xsl:template>
  
  <xsl:template match="readings" mode="morphemepage">
@@ -166,20 +165,15 @@
   <xsl:variable name="morpheme" select="../../@name"/>
   <xsl:variable name="compoundcollector" select="count(addition/utterance/word) - sum(addition/utterance/word/@collector)"/>
   <xsl:variable name="fullasciiform" select="concat($asciiform,'_',$morpheme,'-I-End-',$compoundcollector)"/>
-  <xsl:result-document href="dictionary/{$fullasciiform}.html" method="html" encoding="iso-8859-1">
-  <xsl:message>Writing file for <xsl:value-of select="$fullasciiform"/></xsl:message>
-  <html><head>
-   <title><xsl:value-of select="translate($fullasciiform,'_',' ')"/></title>
-  </head><body bgcolor="#FFFFFF">
-   <xsl:apply-templates select="addition/utterance" mode="morphemepage"/>
-   <img src="http://www.suberic.net/~dmm/cgi-bin/rikchik.cgi?size=3&amp;message={$morpheme}-I-End-{$compoundcollector}" alt="{@name}" width="73" height="73"/>
-   <h1><xsl:value-of select="translate($fullasciiform,'_',' ')"/><xsl:apply-templates select="gloss"/></h1>
+  <page-body href="dictionary/{$fullasciiform}.html" title="{translate($fullasciiform,'_',' ')}" >
+    <xsl:apply-templates select="addition/utterance" mode="morphemepage"/>
+    <img src="http://www.suberic.net/~dmm/cgi-bin/rikchik.cgi?size=3&amp;message={$morpheme}-I-End-{$compoundcollector}" alt="{@name}" width="73" height="73"/>
+    <h1><xsl:value-of select="translate($fullasciiform,'_',' ')"/><xsl:apply-templates select="gloss"/></h1>
    <b>Paradigm:</b>&#xA0;<xsl:value-of select="../../@paradigm"/><br/>
    <xsl:apply-templates select="readings | roles | idioms | compounds" mode="morphemepage"/> 
    <hr/>
    <xsl:apply-templates select=".//note" mode="morphemepage" />
-  </body></html>
-  </xsl:result-document>
+  </page-body>
  </xsl:template>
 
  <xsl:template match="idiom" mode="morphemepage">
@@ -255,20 +249,17 @@
  </xsl:template>
  
  <xsl:template match="paradigm" mode="paradigmpage">
-  <xsl:variable name="titlecasename"><xsl:value-of select="translate(substring(@name,1,1),'abcdefghijklmnopqrstuvwxyz','ABCDEFGHIJKLMNOPQRSTUVWXYZ')"/><xsl:value-of select="substring(@name,2)"/></xsl:variable>
-  <xsl:result-document href="paradigms/{@name}.html" method="html" encoding="iso-8859-1">
-   <xsl:message>Writing file for <xsl:value-of select="@name"/></xsl:message>
-   <html><head>
-    <title><xsl:value-of select="$titlecasename"/> Paradigm</title>
-   </head><body bgcolor="#FFFFFF">
+   <xsl:variable name="titlecasename"><xsl:value-of select="translate(substring(@name,1,1),'abcdefghijklmnopqrstuvwxyz','ABCDEFGHIJKLMNOPQRSTUVWXYZ')"/><xsl:value-of select="substring(@name,2)"/></xsl:variable>
+   <xsl:variable name="output">
+   <page-body title="{$titlecasename} Paradigm" href="paradigms/{@name}.html">
     <h1><xsl:value-of select="$titlecasename"/> Paradigm</h1>
     <xsl:apply-templates select="readings | roles | idioms | compounds" mode="morphemepage"/> 
 
     <!-- report -->
     <xsl:apply-templates select="." mode="paradigmreport"/>
-   </body></html>
-   
-  </xsl:result-document>
+   </page-body>
+   </xsl:variable>
+   <xsl:apply-templates select="$output" mode="output"/>
  </xsl:template>
  <xsl:template mode="paradigmreport" match="paradigm">
   <xsl:variable name="paradigm" select="."/>

--- a/generators/lexicon/morphemepages.xsl
+++ b/generators/lexicon/morphemepages.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="1.1">
+                version="3.0">
  <xsl:import href="rikbasics.xsl"/>
  <xsl:variable name="lang" select="'en'"/>
 
@@ -171,6 +171,32 @@
     <h1><xsl:value-of select="translate($fullasciiform,'_',' ')"/><xsl:apply-templates select="gloss"/></h1>
    <b>Paradigm:</b>&#xA0;<xsl:value-of select="../../@paradigm"/><br/>
    <xsl:apply-templates select="readings | roles | idioms | compounds" mode="morphemepage"/> 
+
+   <h2>Morphemes in this compound</h2>
+   <xsl:variable name="constituents">
+     <x>
+       <xsl:for-each select="addition//word/@morpheme">
+	 <y><xsl:value-of select="."/></y>
+       </xsl:for-each>
+       <y><xsl:value-of select="$morpheme"/></y>
+     </x>
+   </xsl:variable>
+   <xsl:variable name="morphemes" select="/language/morphemes"/>
+   <table cellpadding="0" cellspacing="0" border="0">
+     <tr>
+       <xsl:for-each select="$constituents//y">
+	 <xsl:variable name="y" select="string(.)"/>
+	 <xsl:if test="not(preceding-sibling//y[.=$y])">
+	   <xsl:variable name="morpheme" select="$morphemes/morpheme[@name=$y]"/>
+	   <td align="center">
+	     <xsl:apply-templates select="$morpheme" mode="basiclinkentry"/>
+	     <xsl:comment><xsl:copy-of select="$morpheme"/></xsl:comment>
+	   </td>
+	   <td>&#xa0;&#xa0;</td>
+	 </xsl:if>
+       </xsl:for-each>
+     </tr>
+   </table>
    <xsl:apply-templates select=".//note" mode="morphemepage" />
   </page-body>
  </xsl:template>

--- a/generators/lexicon/morphemepages.xsl
+++ b/generators/lexicon/morphemepages.xsl
@@ -166,12 +166,11 @@
   <xsl:variable name="compoundcollector" select="count(addition/utterance/word) - sum(addition/utterance/word/@collector)"/>
   <xsl:variable name="fullasciiform" select="concat($asciiform,'_',$morpheme,'-I-End-',$compoundcollector)"/>
   <page-body href="dictionary/{$fullasciiform}.html" title="{translate($fullasciiform,'_',' ')}" >
-    <xsl:apply-templates select="addition/utterance" mode="morphemepage"/>
-    <img src="http://www.suberic.net/~dmm/cgi-bin/rikchik.cgi?size=3&amp;message={$morpheme}-I-End-{$compoundcollector}" alt="{@name}" width="73" height="73"/>
+    <!-- xsl:apply-templates select="addition/utterance" mode="morphemepage"/ -->
+    <img src="http://www.suberic.net/~dmm/cgi-bin/rikchik.cgi?size=3&amp;message={$fullasciiform}" alt="{$fullasciiform}"/>
     <h1><xsl:value-of select="translate($fullasciiform,'_',' ')"/><xsl:apply-templates select="gloss"/></h1>
    <b>Paradigm:</b>&#xA0;<xsl:value-of select="../../@paradigm"/><br/>
    <xsl:apply-templates select="readings | roles | idioms | compounds" mode="morphemepage"/> 
-   <hr/>
    <xsl:apply-templates select=".//note" mode="morphemepage" />
   </page-body>
  </xsl:template>

--- a/generators/lexicon/morphemepages.xsl
+++ b/generators/lexicon/morphemepages.xsl
@@ -17,13 +17,25 @@
  </xsl:template>
 
  <xsl:template match="morpheme" mode="morphemepage">
+   <xsl:variable name="is-subdir" select="'yes'"/>
    <xsl:variable name="output">
      <page-body href="dictionary/{@name}.html" title="{@name}">
        <img src="http://www.suberic.net/~dmm/rikchik/images/blunt/5/m{@name}.png" alt="{@name}" width="70" height="70"/>
        <xsl:apply-templates select="glyph/note" mode="noteref"/>
        <h1><xsl:value-of select="@name"/></h1>
        <b>Paradigm:</b>&#xA0;<xsl:value-of select="@paradigm"/><br/>
-       <xsl:apply-templates select="readings | roles | idioms | compounds" mode="morphemepage"/> 
+       <xsl:apply-templates select="readings | roles | idioms | compounds" mode="morphemepage">
+	 <xsl:with-param name="is-subdir" select="$is-subdir" tunnel="yes"/>
+       </xsl:apply-templates>
+       <xsl:if test="not(compounds)">
+	 <xsl:variable name="other-compounds" select="//compound[addition/utterance/word/@morpheme = current()/@name]"/>
+	 <xsl:if test="$other-compounds">
+	   <h3>Compounds</h3>
+	   <xsl:apply-templates select="$other-compounds" mode="linkentry">
+	     <xsl:with-param name="is-subdir" select="$is-subdir" tunnel="yes"/>
+	   </xsl:apply-templates>
+	 </xsl:if>
+       </xsl:if>
        <hr/>
        <xsl:apply-templates select=".//note" mode="morphemepage" />
      </page-body>
@@ -141,7 +153,7 @@
   <h3>Compounds</h3>
   <xsl:apply-templates select="compound" mode="morphemepage"/>
    <xsl:variable name="current-morpheme" select="ancestor::morpheme"/>
-   <xsl:apply-templates select="//compound[addition/utterance/word/@morpheme = $current-morpheme/@name]" mode="innerlinkentry"/>
+   <xsl:apply-templates select="//compound[addition/utterance/word/@morpheme = $current-morpheme/@name]" mode="linkentry"/>
  </xsl:template>
 
  <xsl:template match="idioms" mode="morphemepage">
@@ -154,7 +166,7 @@
  </xsl:template>
 
  <xsl:template match="compound" mode="morphemepage">
-   <xsl:apply-templates select="." mode="innerlinkentry"/>
+   <xsl:apply-templates select="." mode="linkentry"/>
    <xsl:apply-templates select="." mode="compoundpage"/>
  </xsl:template>
 
@@ -165,12 +177,15 @@
   <xsl:variable name="morpheme" select="../../@name"/>
   <xsl:variable name="compoundcollector" select="count(addition/utterance/word) - sum(addition/utterance/word/@collector)"/>
   <xsl:variable name="fullasciiform" select="concat($asciiform,'_',$morpheme,'-I-End-',$compoundcollector)"/>
+  <xsl:variable name="is-subdir" select="'yes'"/>
   <page-body href="dictionary/{$fullasciiform}.html" title="{translate($fullasciiform,'_',' ')}" >
     <!-- xsl:apply-templates select="addition/utterance" mode="morphemepage"/ -->
     <img src="http://www.suberic.net/~dmm/cgi-bin/rikchik.cgi?size=3&amp;message={$fullasciiform}" alt="{$fullasciiform}"/>
     <h1><xsl:value-of select="translate($fullasciiform,'_',' ')"/><xsl:apply-templates select="gloss"/></h1>
    <b>Paradigm:</b>&#xA0;<xsl:value-of select="../../@paradigm"/><br/>
-   <xsl:apply-templates select="readings | roles | idioms | compounds" mode="morphemepage"/> 
+   <xsl:apply-templates select="readings | roles | idioms | compounds" mode="morphemepage">
+     <xsl:with-param name="is-subdir" select="$is-subdir" tunnel="yes"/>
+   </xsl:apply-templates>
 
    <h2>Morphemes in this compound</h2>
    <xsl:variable name="constituents">
@@ -275,10 +290,13 @@
  
  <xsl:template match="paradigm" mode="paradigmpage">
    <xsl:variable name="titlecasename"><xsl:value-of select="translate(substring(@name,1,1),'abcdefghijklmnopqrstuvwxyz','ABCDEFGHIJKLMNOPQRSTUVWXYZ')"/><xsl:value-of select="substring(@name,2)"/></xsl:variable>
+   <xsl:variable name="is-subdir" select="'yes'"/>
    <xsl:variable name="output">
    <page-body title="{$titlecasename} Paradigm" href="paradigms/{@name}.html">
     <h1><xsl:value-of select="$titlecasename"/> Paradigm</h1>
-    <xsl:apply-templates select="readings | roles | idioms | compounds" mode="morphemepage"/> 
+    <xsl:apply-templates select="readings | roles | idioms | compounds" mode="morphemepage">
+      <xsl:with-param name="is-subdir" select="$is-subdir" tunnel="yes"/>
+    </xsl:apply-templates>
 
     <!-- report -->
     <xsl:apply-templates select="." mode="paradigmreport"/>

--- a/generators/lexicon/nameindex.xsl
+++ b/generators/lexicon/nameindex.xsl
@@ -7,14 +7,15 @@
  <xsl:output method="html" encoding="iso-8859-1"/>
  
  <xsl:template match="/">
-  <xsl:apply-templates select="language" mode="indexpage"/>
+   <xsl:variable name="output">
+     <xsl:apply-templates select="language" mode="indexpage"/>
+   </xsl:variable>
+   <xsl:apply-templates select="$output" mode="output"/>
  </xsl:template>
  
  <!-- indexes -->
  <xsl:template match="language" mode="indexpage">
-  <html><head>
-  <title>Morpheme Dictionary</title>
-  </head><body bgcolor="#FFFFFF">
+   <page-body href="dictionary.html" title="Morpheme Dictionary">
   <h1>Morpheme Dictionary</h1>
   <ul>
   <li><a href="#name">By Name</a></li>
@@ -33,8 +34,8 @@
   <table cellpadding="0" cellspacing="0" border="0">
    <xsl:apply-templates select="//morpheme" mode="nameindexentry"/>
   </table>
-  </body></html>
   <xsl:apply-templates select="//morphemes" mode="morphemequicklist"/>
+   </page-body>
  </xsl:template>
 
  <xsl:template match="morphemes" mode="indexname">
@@ -94,19 +95,14 @@
  <xsl:template match="morpheme" mode="paradigmindexentry"/>
 
  <xsl:template match="morphemes" mode="morphemequicklist">
-  <xsl:message>writing quick list</xsl:message>
-  <xsl:result-document href="quicklist.html" method="html" encoding="iso-8859-1">
-   <html><head>
-    <title>Morpheme Dictionary</title>
-   </head><body bgcolor="#FFFFFF" link="#FFFFFF" vlink="#FFFFFF" alink="#003300">
-    <h1>Morpheme Quick List</h1>
-    <xsl:for-each select="morpheme">
-     <a href="dictionary/{@name}.html">
-     <img src="http://www.suberic.net/~dmm/rikchik/images/classic/3/m{@name}.png" alt="{@name}" border="5" width="42" height="42"/>
-     </a>
-    </xsl:for-each>
-   </body></html>
-  </xsl:result-document>
+   <page-body href="quicklist.html" title="Morpheme Dictionary">
+     <h1>Morpheme Quick List</h1>
+     <xsl:for-each select="morpheme">
+       <a href="dictionary/{@name}.html" class="quick">
+	 <img src="http://www.suberic.net/~dmm/rikchik/images/classic/3/m{@name}.png" alt="{@name}" border="5" width="42" height="42"/>
+       </a>
+     </xsl:for-each>
+   </page-body>
  </xsl:template>
 
  <!-- /indexes -->

--- a/generators/lexicon/rikbasics.xsl
+++ b/generators/lexicon/rikbasics.xsl
@@ -152,4 +152,34 @@
    <xsl:text>)</xsl:text>
  </xsl:template>
 
+ <xsl:template match="page-body" mode="output">
+   <xsl:message>Writing file for <xsl:value-of select="@title"/></xsl:message>
+   <xsl:result-document href="{@href}" method="html" encoding="iso-8859-1">
+     <html>
+       <head>
+	 <title><xsl:value-of select="@title"/></title>
+	 <style><!-- link="#FFFFFF" vlink="#FFFFFF" alink="#003300" -->
+	   a.quick:link, a.quick:visited {
+	     color: #FFFFFF;
+	   }
+
+	   a.quick:hover, a.quick:active {
+	     color: #003300;
+	   }
+	 </style>
+       </head>
+       <body bgcolor="#FFFFFF">
+	 <xsl:apply-templates mode="output"/>
+       </body>
+     </html>
+   </xsl:result-document>
+ </xsl:template>
+
+ <xsl:template match="*" mode="output">
+   <xsl:copy>
+     <xsl:copy-of select="@*"/>
+     <xsl:apply-templates mode="output"/>
+   </xsl:copy>
+ </xsl:template>
+ 
 </xsl:stylesheet>

--- a/generators/lexicon/rikbasics.xsl
+++ b/generators/lexicon/rikbasics.xsl
@@ -157,7 +157,7 @@
    <xsl:result-document href="{@href}" method="html" encoding="iso-8859-1">
      <html>
        <head>
-	 <title><xsl:value-of select="@title"/></title>
+	 <title><xsl:text>Rikchik Language Reference Dictionary: </xsl:text><xsl:value-of select="@title"/></title>
 	 <style><!-- link="#FFFFFF" vlink="#FFFFFF" alink="#003300" -->
 	   a.quick:link, a.quick:visited {
 	     color: #FFFFFF;
@@ -170,6 +170,7 @@
        </head>
        <body bgcolor="#FFFFFF">
 	 <xsl:apply-templates mode="output"/>
+	 <xsl:apply-templates select="." mode="footer"/>
        </body>
      </html>
    </xsl:result-document>
@@ -180,6 +181,26 @@
      <xsl:copy-of select="@*"/>
      <xsl:apply-templates mode="output"/>
    </xsl:copy>
+ </xsl:template>
+ 
+ <xsl:template match="page-body" mode="footer">
+   <xsl:variable name="backdir">
+     <xsl:if test="count(tokenize(@href, '/')) &gt; 1">
+       <xsl:text>../</xsl:text>
+     </xsl:if> 
+   </xsl:variable>
+   <hr />
+   <address>
+     Part of the <a href="{$backdir}dictionary.html">Rikchik Language Reference Dictionary</a>.
+     <a href="/~dmm/rikchik/intro.html">Rikchik culture and language</a> 
+     by Denis Moskowitz. 
+     Word assembly program utilizes 
+     <a href="http://www.boutell.com/gd/">gd</a>, a graphics library, and
+     <a href="http://www-genome.wi.mit.edu/ftp/pub/software/WWW/GD.html">GD.pm</a>,
+     a perl interface to gd. gd is &#xA9; 1994, 1995, Quest Protein Database 
+     Center, Cold Spring Harbor Labs.  GD.pm is &#xA9; 1995, Lincoln D. Stein.
+     Both are used with permission.
+   </address>
  </xsl:template>
  
 </xsl:stylesheet>

--- a/generators/lexicon/rikbasics.xsl
+++ b/generators/lexicon/rikbasics.xsl
@@ -9,8 +9,12 @@
 
  <xsl:template match="morpheme" mode="url">
    <xsl:param name="inner"/>
+   <xsl:param name="is-subdir"/>
    <xsl:if test="not($inner)">
      <xsl:text>dictionary/</xsl:text>
+   </xsl:if>
+   <xsl:if test="$is-subdir">
+     <xsl:text>../</xsl:text>
    </xsl:if>
    <xsl:value-of select="@name"/>
    <xsl:text>.html</xsl:text>
@@ -104,8 +108,11 @@
  </xsl:template>
 
  <xsl:template match="morpheme" mode="basiclinkentry">
+   <param name="is-subdir"/>
    <xsl:variable name="href">
-     <xsl:apply-templates select="." mode="url"/>
+     <xsl:apply-templates select="." mode="url">
+       <xsl:with-param name="is-subdir" select="$is-subdir"/>
+     </xsl:apply-templates>
    </xsl:variable>
    <a href="{$href}"><img src="http://www.suberic.net/~dmm/rikchik/images/{$entrystyle}/3/m{@name}.png" alt="{@name}" border="0" width="42" height="42"/></a><br/>
    <a href="{$href}"><xsl:value-of select="@name"/></a>&#xA0;<br/><br/>

--- a/generators/lexicon/rikbasics.xsl
+++ b/generators/lexicon/rikbasics.xsl
@@ -8,27 +8,25 @@
  <xsl:variable name="textstyle" select="'classic'"/>
 
  <xsl:template match="morpheme" mode="url">
-   <xsl:param name="inner"/>
-   <xsl:param name="is-subdir"/>
-   <xsl:if test="not($inner)">
-     <xsl:text>dictionary/</xsl:text>
-   </xsl:if>
+   <xsl:param name="is-subdir" tunnel="yes"/>
    <xsl:if test="$is-subdir">
      <xsl:text>../</xsl:text>
    </xsl:if>
+   <xsl:text>dictionary/</xsl:text>
    <xsl:value-of select="@name"/>
    <xsl:text>.html</xsl:text>
  </xsl:template>
 
  <xsl:template match="compound" mode="url">
-   <xsl:param name="inner"/>
+    <xsl:param name="is-subdir" tunnel="yes"/>
   <xsl:variable name="asciiform"
    ><xsl:apply-templates select="addition/utterance" mode="asciiform"
   /></xsl:variable>
   <xsl:variable name="compoundcollector" select="count(addition/utterance/word) - sum(addition/utterance/word/@collector)"/>
-   <xsl:if test="not($inner)">
-     <xsl:text>dictionary/</xsl:text>
+   <xsl:if test="$is-subdir">
+     <xsl:text>../</xsl:text>
    </xsl:if>
+   <xsl:text>dictionary/</xsl:text>
    <xsl:value-of select="$asciiform"/>
    <xsl:text>_</xsl:text>
    <xsl:value-of select="../../@name"/>
@@ -38,7 +36,6 @@
  </xsl:template>
 
  <xsl:template match="reading" mode="url">
-   <xsl:param name="inner"/>
    <xsl:apply-templates select="../.." mode="url"/>
    <xsl:text>#reading-</xsl:text>
    <xsl:value-of select="@aspect"/>
@@ -48,14 +45,7 @@
    <xsl:apply-templates select="." mode="linkentry"/>
  </xsl:template>
 
- <xsl:template match="compound" mode="innerlinkentry">
-   <xsl:apply-templates select="." mode="linkentry">
-     <xsl:with-param name="inner" select="'true'"/>
-   </xsl:apply-templates>
- </xsl:template>
-
  <xsl:template match="compound" mode="linkentry">
-  <xsl:param name="inner"/>
   <xsl:variable name="compoundcollector" select="count(addition/utterance/word) - sum(addition/utterance/word/@collector)"/>
   <xsl:variable name="utterance">
     <utterance>
@@ -67,9 +57,7 @@
    ><xsl:apply-templates select="$utterance" mode="asciiform"
   /></xsl:variable>
   <xsl:variable name="href">
-    <xsl:apply-templates select="." mode="url">
-      <xsl:with-param name="inner" select="$inner"/>
-    </xsl:apply-templates>
+    <xsl:apply-templates select="." mode="url"/>
   </xsl:variable>
   <p>
   <a href="{$href}">
@@ -84,7 +72,6 @@
  </xsl:template>
 
  <xsl:template match="compound/readings/reading" mode="linkentry">
-  <xsl:param name="inner"/>
   <xsl:variable name="morpheme" select="../../../../@name"/>
   <xsl:variable name="compoundcollector" select="count(../../addition/utterance/word) - sum(../../addition/utterance/word/@collector)"/>
   <xsl:variable name="utterance">
@@ -97,9 +84,7 @@
    ><xsl:apply-templates select="$utterance" mode="asciiform"
   /></xsl:variable>
   <xsl:variable name="href">
-    <xsl:apply-templates select="." mode="url">
-      <xsl:with-param name="inner" select="$inner"/>
-    </xsl:apply-templates>
+    <xsl:apply-templates select="." mode="url"/>
   </xsl:variable>
   <p>
   <a href="{$href}"><xsl:apply-templates select="$utterance" mode="morphemepage">
@@ -108,11 +93,8 @@
  </xsl:template>
 
  <xsl:template match="morpheme" mode="basiclinkentry">
-   <param name="is-subdir"/>
    <xsl:variable name="href">
-     <xsl:apply-templates select="." mode="url">
-       <xsl:with-param name="is-subdir" select="$is-subdir"/>
-     </xsl:apply-templates>
+     <xsl:apply-templates select="." mode="url"/>
    </xsl:variable>
    <a href="{$href}"><img src="http://www.suberic.net/~dmm/rikchik/images/{$entrystyle}/3/m{@name}.png" alt="{@name}" border="0" width="42" height="42"/></a><br/>
    <a href="{$href}"><xsl:value-of select="@name"/></a>&#xA0;<br/><br/>
@@ -139,7 +121,10 @@
   <xsl:variable name="asciiform">
     <xsl:apply-templates select="utterance" mode="asciiform"/>
   </xsl:variable>
-  <a href="dictionary/{ancestor::morpheme/@name}.html#{$asciiform}">
+  <xsl:variable name="ancestor-url">
+    <xsl:apply-templates select="ancestor::morpheme" mode="url"/>
+  </xsl:variable>
+  <a href="{ancestor-url}#{$asciiform}">
     <xsl:apply-templates select="utterance" mode="morphemepage"/><br/>
     <xsl:value-of select="translate($asciiform,'_',' ')"/>
   </a>

--- a/generators/lexicon/riklang.xsl
+++ b/generators/lexicon/riklang.xsl
@@ -11,21 +11,24 @@
  <!-- for the riklang document -->
  <xsl:template match="/">
   <!-- put todopage in todo.html -->
-  <xsl:result-document href="todo.html" method="html" encoding="iso-8859-1">
-   <xsl:apply-templates select="language" mode="todopage"/>
-  </xsl:result-document>
+  <xsl:variable name="todopage-output">
+    <xsl:apply-templates select="language" mode="todopage"/>
+  </xsl:variable>
+  <xsl:apply-templates select="$todopage-output" mode="output"/>  
   <!-- create the paradigms -->
   <xsl:apply-templates select="//paradigms" mode="paradigmpages"/>
   <!-- create the morphemes -->
   <xsl:apply-templates select="//morphemes" mode="morphemepages"/>
   <!-- create the dictionary index -->
-  <xsl:result-document href="dictionary.html" method="html" encoding="iso-8859-1">
-   <xsl:apply-templates select="language" mode="indexpage"/>
-  </xsl:result-document>
+  <xsl:variable name="indexpage-output">
+    <xsl:apply-templates select="language" mode="indexpage"/>
+  </xsl:variable>
+  <xsl:apply-templates select="$indexpage-output" mode="output"/>
   <!-- create the english dictionary index -->
-  <xsl:result-document href="engdict.html" method="html" encoding="iso-8859-1">
-   <xsl:apply-templates select="/" mode="engdict"/>
-  </xsl:result-document>
+  <xsl:variable name="engdict-output">
+    <xsl:apply-templates select="/" mode="engdict"/>
+  </xsl:variable>
+  <xsl:apply-templates select="$engdict-output" mode="output"/>
  </xsl:template>
 
 </xsl:stylesheet>

--- a/generators/lexicon/todo.xsl
+++ b/generators/lexicon/todo.xsl
@@ -15,13 +15,11 @@
     </xsl:template>
 
     <xsl:template match="language" mode="todopage">
-	<html>
-	<body>
+      <page-body href="todo.html" title="Todo Page">
 	  <h1>Todo page!</h1>
 	  <p>This is a utility page noting what parts of the language are defined and what are yet to be defined.</p>
-	    <xsl:apply-templates select="//morphemes" mode="todopage"/>
-	</body>
-	</html>
+	  <xsl:apply-templates select="//morphemes" mode="todopage"/>
+      </page-body>
     </xsl:template>
 
     <xsl:template match="morphemes" mode="todopage">


### PR DESCRIPTION
This PR makes some rendering changes in the lexicon. Specifically:

1. Page creation is now done at a single point in the code based on a simple page-body element that only has a title and an href attribute
2. Based on this, a footer and a standardized title have been added
3. Compounds now contain links back to their consituent morphemes
4. Morphemes that appear in compounds but never as the base now display those morphemes
5. URL generation has been standardized and simplified using tunnel params
